### PR TITLE
Will start uploadscript dependency when option CallUploadScript is en…

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -92,6 +92,13 @@ directory node['pure-ftpd']['virtual_users_root'] do
   action :create
 end if node['pure-ftpd']['virtual_users_root']
 
+if node['pure-ftpd']['options']['enabled'].include? "CallUploadScript"
+  service 'pure-uploadscript' do
+    supports start: true, stop: true
+    action [:enable, :start]
+  end
+end
+
 # Enables and restarts Pure-FTPd service.
 service node['pure-ftpd']['package'] do
   supports status: true, restart: true


### PR DESCRIPTION
…abled

In systemd, pure-ftpd will fail to start when -o option is used (CallUploadScript enabled) but the upload script daemon is not running.  It is assumed that the service init file/template is provided by the calling/wrapper cookbook.  The service can not be started there because it relies on the installation of pure-uploadscript, which is provided by this cookbook.